### PR TITLE
83 - resized logo, removed max prefix in img css

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -5,11 +5,8 @@
 header {
     width: 100%;
     text-align: center;
-    padding: 30px;
-    display: flex;
-    letter-spacing: 30px;
+    padding: 20px;
     box-shadow: 0px 0px 20px 20px #00000044;
-    justify-content: center;
 }
 
 body {
@@ -17,13 +14,18 @@ body {
 }
 
 img {
-    max-width: 100px;
-    max-height: 100px;
+    width: 100px;
+    height: 100px;
     margin: 10px;
 }
 
-h1 {
+/* h1 {
     color: #78502b;
+} */
+
+.appLogo{
+    height: 100px;
+    width: 300px;
 }
 
 h2 {
@@ -35,7 +37,7 @@ h2 {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 75vh; /* Adjust the height as needed */
+    height: 65vh; /* Adjust the height as needed */
   }
   
   .startPage,

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
 <body>
     <header>
-        <img src="./Assets/images/kumamo brown.png" alt="kumamo title text">
+        <img class="appLogo" src="./Assets/images/kumamo brown.png" alt="kumamo title text">
     </header>
 
     <section class="container">


### PR DESCRIPTION
changelog:

added class name "applogo" to ... app logo

removed h1 styles in css

remove "max" prefix in width and height in img tag in css, it would have forced all images to only have a max size of 100 by 100 pixels no matter how we change it. this should now also help resolve the small size of the recipe image and nutrition infobox.

added .appLogo and resized app logo with height of 100px and width of 300px
